### PR TITLE
Feat: MCP server proxy

### DIFF
--- a/src/lib/nextjs-runtime-manager.ts
+++ b/src/lib/nextjs-runtime-manager.ts
@@ -1,0 +1,193 @@
+import { exec } from "child_process"
+import { promisify } from "util"
+
+const execAsync = promisify(exec)
+
+interface NextJsServerInfo {
+  port: number
+  pid: number
+  command: string
+}
+
+interface NextJsMCPTool {
+  name: string
+  description?: string
+  inputSchema?: Record<string, unknown>
+}
+
+interface NextJsMCPResponse {
+  jsonrpc: string
+  result?: {
+    tools?: NextJsMCPTool[]
+    [key: string]: unknown
+  }
+  error?: {
+    code: number
+    message: string
+  }
+  id: number | string
+}
+
+async function findNextJsServers(): Promise<NextJsServerInfo[]> {
+  try {
+    const { stdout } = await execAsync("ps aux")
+    const lines = stdout.split("\n")
+    const servers: NextJsServerInfo[] = []
+
+    for (const line of lines) {
+      if (line.includes("next dev") || line.includes("next-server")) {
+        const parts = line.trim().split(/\s+/)
+        const pid = parseInt(parts[1], 10)
+        const command = parts.slice(10).join(" ")
+
+        const portMatch = command.match(/--port[=\s]+(\d+)/) || command.match(/:(\d+)/)
+        let port = 3000
+
+        if (portMatch) {
+          port = parseInt(portMatch[1], 10)
+        } else {
+          const processInfo = await execAsync(`lsof -Pan -p ${pid} -i 2>/dev/null || true`)
+          const portFromLsof = processInfo.stdout.match(/:(\d+).*LISTEN/)
+          if (portFromLsof) {
+            port = parseInt(portFromLsof[1], 10)
+          }
+        }
+
+        servers.push({ port, pid, command })
+      }
+    }
+
+    return servers
+  } catch (error) {
+    console.error("[Next.js Runtime Manager] Error finding Next.js servers:", error)
+    return []
+  }
+}
+
+async function makeNextJsMCPRequest(
+  port: number,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<NextJsMCPResponse> {
+  const url = `http://localhost:${port}/_next/mcp`
+
+  const jsonRpcRequest = {
+    jsonrpc: "2.0",
+    method,
+    params,
+    id: Date.now(),
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      },
+      body: JSON.stringify(jsonRpcRequest),
+    })
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(
+          `MCP endpoint not found. Next.js MCP support requires Next.js 16+. ` +
+          `If you're on an older version, upgrade using the 'upgrade-nextjs-16' MCP prompt. ` +
+          `If you're already on Next.js 16+, ensure you're running the dev server with ` +
+          `__NEXT_EXPERIMENTAL_MCP_SERVER=true or experimental.mcpServer: true in next.config.js`
+        )
+      }
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+    }
+
+    const text = await response.text()
+    const dataLine = text.split("\n").find((line) => line.startsWith("data: "))
+
+    if (!dataLine) {
+      throw new Error("Invalid SSE response: no data line found")
+    }
+
+    const jsonData = dataLine.substring(6)
+    const mcpResponse: NextJsMCPResponse = JSON.parse(jsonData)
+
+    if (mcpResponse.error) {
+      throw new Error(`MCP Error: ${mcpResponse.error.message}`)
+    }
+
+    return mcpResponse
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes("fetch failed")) {
+      throw new Error(
+        `Cannot connect to Next.js dev server on port ${port}. ` +
+        `Ensure the server is running with __NEXT_EXPERIMENTAL_MCP_SERVER=true or ` +
+        `experimental.mcpServer: true in next.config.js. ` +
+        `If you're on Next.js 15 or earlier, upgrade to Next.js 16+ using the 'upgrade-nextjs-16' MCP prompt.`
+      )
+    }
+
+    if (
+      error instanceof Error &&
+      (error.message.includes("MCP endpoint not found") || error.message.includes("MCP Error"))
+    ) {
+      throw error
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to call Next.js MCP endpoint: ${errorMessage}`)
+  }
+}
+
+export async function discoverNextJsServer(
+  preferredPort?: number
+): Promise<NextJsServerInfo | null> {
+  const servers = await findNextJsServers()
+
+  if (servers.length === 0) {
+    return null
+  }
+
+  if (preferredPort) {
+    const server = servers.find((s) => s.port === preferredPort)
+    if (server) {
+      return server
+    }
+  }
+
+  if (servers.length === 1) {
+    return servers[0]
+  }
+
+  return null
+}
+
+export async function listNextJsTools(port: number): Promise<NextJsMCPTool[]> {
+  try {
+    const response = await makeNextJsMCPRequest(port, "tools/list", {})
+    return response.result?.tools || []
+  } catch (error) {
+    console.error("[Next.js Runtime Manager] Error listing tools:", error)
+    return []
+  }
+}
+
+export async function callNextJsTool(
+  port: number,
+  toolName: string,
+  args: Record<string, unknown>
+): Promise<unknown> {
+  try {
+    const response = await makeNextJsMCPRequest(port, "tools/call", {
+      name: toolName,
+      arguments: args,
+    })
+
+    return response.result
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    throw new Error(`Failed to call tool '${toolName}': ${errorMessage}`)
+  }
+}
+
+export async function getAllAvailableServers(): Promise<NextJsServerInfo[]> {
+  return findNextJsServers()
+}

--- a/src/mcp-tools/index.ts
+++ b/src/mcp-tools/index.ts
@@ -1,12 +1,15 @@
 export { nextjsDocsTool } from "./nextjs-docs.js"
 export { playwrightTool } from "./playwright.js"
+export { nextjsRuntimeTool } from "./nextjs-runtime.js"
 
 // Export tools registry
 import { nextjsDocsTool } from "./nextjs-docs.js"
 import { playwrightTool } from "./playwright.js"
+import { nextjsRuntimeTool } from "./nextjs-runtime.js"
 
 export const MCP_TOOLS = {
   nextjs_docs: nextjsDocsTool,
   playwright: playwrightTool,
+  nextjs_runtime: nextjsRuntimeTool,
 } as const
 

--- a/src/mcp-tools/nextjs-runtime.ts
+++ b/src/mcp-tools/nextjs-runtime.ts
@@ -1,0 +1,167 @@
+import { tool } from "ai"
+import { z } from "zod"
+import {
+  discoverNextJsServer,
+  listNextJsTools,
+  callNextJsTool,
+  getAllAvailableServers,
+} from "../lib/nextjs-runtime-manager.js"
+
+const nextjsRuntimeInputSchema = z.object({
+  action: z
+    .enum(["discover_servers", "list_tools", "call_tool"])
+    .describe(
+      "Action to perform: 'discover_servers' finds running Next.js servers, 'list_tools' lists available MCP tools from the Next.js runtime, 'call_tool' calls a specific tool"
+    ),
+
+  port: z
+    .number()
+    .optional()
+    .describe(
+      "Port number of the Next.js dev server. If not provided, will attempt to auto-discover. Required for 'list_tools' and 'call_tool' actions."
+    ),
+
+  toolName: z
+    .string()
+    .optional()
+    .describe(
+      "Name of the Next.js MCP tool to call. Required for 'call_tool' action. Use 'list_tools' first to discover available tool names."
+    ),
+
+  args: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe(
+      "Arguments object to pass to the Next.js MCP tool. MUST be an object (e.g., {param: 'value'}), NOT a string. Only provide this parameter if the tool requires arguments - omit it entirely for tools that take no arguments. Use 'list_tools' to see the inputSchema for each tool."
+    ),
+})
+
+export const nextjsRuntimeTool = tool({
+  description: `Interact with a running Next.js development server's MCP endpoint.
+
+REQUIREMENTS:
+- Next.js 16 or later (MCP support was added in v16)
+- If you're on Next.js 15 or earlier, use the 'upgrade-nextjs-16' MCP prompt to upgrade first
+
+Next.js exposes an MCP (Model Context Protocol) endpoint at /_next/mcp when started with:
+- experimental.mcpServer: true in next.config.js, OR
+- __NEXT_EXPERIMENTAL_MCP_SERVER=true environment variable
+
+This tool allows you to:
+1. Discover running Next.js dev servers and their ports
+2. List available MCP tools/functions exposed by the Next.js runtime
+3. Call those tools to interact with Next.js internals (e.g., get route info, clear cache, etc.)
+
+Typical workflow:
+1. Use action='discover_servers' to find running Next.js servers
+2. Use action='list_tools' with the discovered port to see available tools and their input schemas
+3. Use action='call_tool' with port, toolName, and args (as an object, only if required) to invoke a specific tool
+
+IMPORTANT: When calling tools:
+- The 'args' parameter MUST be an object (e.g., {key: "value"}), NOT a string
+- If a tool doesn't require arguments, OMIT the 'args' parameter entirely - do NOT pass {} or "{}"
+- Check the tool's inputSchema from 'list_tools' to see what arguments are required
+
+If the MCP endpoint is not available:
+1. Check if you're running Next.js 16+ (if not, use the 'upgrade-nextjs-16' prompt)
+2. Ensure the dev server is started with __NEXT_EXPERIMENTAL_MCP_SERVER=true or experimental.mcpServer: true`,
+  inputSchema: nextjsRuntimeInputSchema,
+  execute: async (args: z.infer<typeof nextjsRuntimeInputSchema>): Promise<string> => {
+    try {
+      switch (args.action) {
+        case "discover_servers": {
+          const servers = await getAllAvailableServers()
+
+          if (servers.length === 0) {
+            return JSON.stringify({
+              success: false,
+              message: "No running Next.js dev servers found",
+              hint: "Start a Next.js dev server with __NEXT_EXPERIMENTAL_MCP_SERVER=true or experimental.mcpServer: true",
+            })
+          }
+
+          return JSON.stringify({
+            success: true,
+            servers: servers.map((s) => ({
+              port: s.port,
+              pid: s.pid,
+              command: s.command,
+            })),
+            message: `Found ${servers.length} Next.js server(s)`,
+          })
+        }
+
+        case "list_tools": {
+          if (!args.port) {
+            const discovered = await discoverNextJsServer()
+            if (!discovered) {
+              return JSON.stringify({
+                success: false,
+                error:
+                  "No port specified and auto-discovery failed. Use action='discover_servers' first or provide a port.",
+              })
+            }
+            args.port = discovered.port
+          }
+
+          const tools = await listNextJsTools(args.port)
+
+          return JSON.stringify({
+            success: true,
+            port: args.port,
+            tools: tools.map((t) => ({
+              name: t.name,
+              description: t.description,
+              inputSchema: t.inputSchema,
+            })),
+            message: `Found ${tools.length} tool(s) available on Next.js server at port ${args.port}`,
+          })
+        }
+
+        case "call_tool": {
+          if (!args.port) {
+            const discovered = await discoverNextJsServer()
+            if (!discovered) {
+              return JSON.stringify({
+                success: false,
+                error:
+                  "No port specified and auto-discovery failed. Use action='discover_servers' first or provide a port.",
+              })
+            }
+            args.port = discovered.port
+          }
+
+          if (!args.toolName) {
+            return JSON.stringify({
+              success: false,
+              error:
+                "toolName is required for 'call_tool' action. Use action='list_tools' to discover available tool names.",
+            })
+          }
+
+          const result = await callNextJsTool(args.port, args.toolName, args.args || {})
+
+          return JSON.stringify({
+            success: true,
+            port: args.port,
+            toolName: args.toolName,
+            result,
+          })
+        }
+
+        default:
+          return JSON.stringify({
+            success: false,
+            error: `Unknown action: ${args.action}`,
+          })
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      return JSON.stringify({
+        success: false,
+        error: errorMessage,
+        action: args.action,
+      })
+    }
+  },
+})

--- a/src/mcp-tools/playwright.ts
+++ b/src/mcp-tools/playwright.ts
@@ -79,6 +79,12 @@ export const playwrightTool = tool({
   description: `Automate and test web applications using Playwright browser automation.
 This tool connects to playwright-mcp server and provides access to all Playwright capabilities.
 
+IMPORTANT FOR NEXT.JS PROJECTS:
+If working with a Next.js application, PRIORITIZE using the 'nextjs_runtime' tool instead of browser console log forwarding.
+Next.js has built-in MCP integration that provides superior error reporting, build diagnostics, and runtime information
+directly from the Next.js dev server. Only use Playwright's console_messages action as a fallback when nextjs_runtime
+tools are not available or when you specifically need to test client-side browser behavior that Next.js runtime cannot capture.
+
 Available actions:
 - start: Start Playwright browser (automatically installs if needed)
 - navigate: Navigate to a URL
@@ -87,7 +93,7 @@ Available actions:
 - fill_form: Fill multiple form fields at once
 - evaluate: Execute JavaScript in browser context
 - screenshot: Take a screenshot of the page
-- console_messages: Get browser console messages
+- console_messages: Get browser console messages (for Next.js, prefer nextjs_runtime tool instead)
 - close: Close the browser
 - drag: Perform drag and drop
 - upload_file: Upload files


### PR DESCRIPTION
Create an MCP tool for Next.js runtime information:
- It works for dev server inside / outside agent
- It fetches the available tools and its schema and dynamically calls the tool
- It decouples itself completely from the version of Next.js