### PR TITLE
handle invalid no arg in tool

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "next-devtools": {
-      "command": "npx",
-      "args": ["."]
+      "command": "node",
+      "args": ["./dist/index.js"]
     }
   }
 }

--- a/src/mcp-tools/nextjs-docs.ts
+++ b/src/mcp-tools/nextjs-docs.ts
@@ -8,7 +8,10 @@ import {
 
 // Next.js Docs Tool
 const nextjsDocsInputSchema = z.object({
-  query: z.string().describe("Search query to find relevant Next.js documentation sections"),
+  query: z
+    .string()
+    .min(1, "Query parameter is required and must be a non-empty string")
+    .describe("Search query to find relevant Next.js documentation sections"),
   category: z
     .enum(["all", "getting-started", "guides", "api-reference", "architecture", "community"])
     .optional()
@@ -136,6 +139,7 @@ Provides access to comprehensive Next.js guides, API references, and best practi
     category = "all",
   }: z.infer<typeof nextjsDocsInputSchema>): Promise<string> => {
     // Step 1: Search MCP resources first (Next.js 16 knowledge base)
+    // Note: Arguments are now validated by Zod at the MCP server level before reaching here
     const mcpMatches = searchMcpResources(query)
 
     if (mcpMatches.length > 0) {


### PR DESCRIPTION
This PR is to avoid LLM calling docs mcp tool without any query, it should always have a query

```
⏺ I'll call the Next.js docs tool without any arguments.
  ⎿  Error: MCP error -32603: Tool execution failed: Invalid arguments - query: Invalid input: expected
     string, received undefined

⏺ The query parameter is required for the Next.js docs tool. It expects a search query string. Would
  you like me to:

  1. Call it with a specific search query?
  2. Try searching for general documentation?
  3. Something else?
```

Closes NXT-88
