### PR TITLE
detect version channel

### DIFF
--- a/src/_internal/nextjs-channel-detector.ts
+++ b/src/_internal/nextjs-channel-detector.ts
@@ -39,17 +39,12 @@ export function detectProjectChannel(projectPath: string): ChannelDetectionResul
 
 /**
  * Processes conditional template blocks based on channel detection
- * Supports {{IF_BETA_CHANNEL}} and {{IF_REQUIRES_CANARY}} blocks
+ * Supports {{IF_BETA_CHANNEL}} blocks
  * @param template - Template string with conditional blocks
  * @param isBeta - Whether the project is on beta channel
- * @param requiresCanary - Whether canary is required
  * @returns Processed template with conditional blocks resolved
  */
-export function processConditionalBlocks(
-  template: string,
-  isBeta: boolean,
-  requiresCanary: boolean
-): string {
+export function processConditionalBlocks(template: string, isBeta: boolean): string {
   let result = template
 
   // Process IF_BETA_CHANNEL blocks
@@ -60,16 +55,6 @@ export function processConditionalBlocks(
   } else {
     // Remove entire block including content
     result = result.replace(/\{\{IF_BETA_CHANNEL\}\}.*?\{\{\/IF_BETA_CHANNEL\}\}/gs, "")
-  }
-
-  // Process IF_REQUIRES_CANARY blocks
-  if (requiresCanary) {
-    // Keep content, remove markers
-    result = result.replace(/\{\{IF_REQUIRES_CANARY\}\}/g, "")
-    result = result.replace(/\{\{\/IF_REQUIRES_CANARY\}\}/g, "")
-  } else {
-    // Remove entire block including content
-    result = result.replace(/\{\{IF_REQUIRES_CANARY\}\}.*?\{\{\/IF_REQUIRES_CANARY\}\}/gs, "")
   }
 
   return result

--- a/src/prompts/upgrade-nextjs-16-prompt.md
+++ b/src/prompts/upgrade-nextjs-16-prompt.md
@@ -328,8 +328,17 @@ After the codemod runs, check for any remaining issues it might have missed:
    File: next.config.js
    Check: `serverComponentsExternalPackages` in experimental config
    Action: Move out of experimental - this is now a top-level config option
-   
+
    **📖 For code examples, see: `nextjs16://migration/examples` (Config Migration Examples)**
+
+   {{IF_BETA_CHANNEL}}**J. Beta to Stable Migration (REQUIRED for beta channel users)**
+
+   You are currently upgrading to Next.js 16 **beta** channel. When Next.js 16 **stable** is released, you will need to apply additional config migrations:
+
+   {{BETA_TO_STABLE_GUIDE}}
+
+   **Key migration when stable is released**: `experimental.cacheLife` must be moved to top-level `cacheLife`{{/IF_BETA_CHANNEL}}
+   
 
 **K. Edge Cases the Codemod May Miss**
    Review these manually:
@@ -535,10 +544,6 @@ Report findings in this format:
 - [ ] Codemod upgraded Next.js, React, and React DOM to stable
 - [ ] Codemod upgraded React type definitions to stable
 - [ ] Codemod applied automatic fixes
-{{IF_REQUIRES_CANARY}}
-- [ ] (Optional) Upgraded to canary: `<pkg-manager> add next@canary`
-- [ ] (Optional) Upgraded eslint-config-next: `<pkg-manager> add -D eslint-config-next@canary`
-{{/IF_REQUIRES_CANARY}}
 - [ ] TypeScript upgraded if needed: `<pkg-manager> add -D typescript@latest`
 - [ ] Reviewed git diff for codemod changes
 - [ ] **Verified build: `<pkg-manager> run build` (if this passes, upgrade is complete!)**

--- a/src/prompts/upgrade-nextjs-16.ts
+++ b/src/prompts/upgrade-nextjs-16.ts
@@ -52,8 +52,7 @@ export default function getUpgradeNextjs16Prompt(args: InferSchema<typeof schema
   promptTemplate = promptTemplate.replace(/{{CODEMOD_COMMAND}}/g, codemodCommandNote)
 
   // Process conditional blocks based on project channel
-  // requiresCanary is false since stable is now available
-  promptTemplate = processConditionalBlocks(promptTemplate, isBeta, false)
+  promptTemplate = processConditionalBlocks(promptTemplate, isBeta)
 
   return promptTemplate
 }

--- a/test/prompts/prompts.test.ts
+++ b/test/prompts/prompts.test.ts
@@ -29,5 +29,18 @@ describe('Prompts Token Size', () => {
 
     expect(estimatedTokens).toBeLessThan(10000)
   })
+
+  it('upgrade-nextjs-16 should not contain unprocessed template markers', () => {
+    const result = getUpgradeNextjs16Prompt({ project_path: undefined })
+
+    // Verify all conditional blocks are processed (no leftover markers)
+    expect(result).not.toContain('{{IF_BETA_CHANNEL}}')
+    expect(result).not.toContain('{{/IF_BETA_CHANNEL}}')
+    
+    // Verify basic template variables are replaced
+    expect(result).not.toContain('{{PROJECT_PATH}}')
+    expect(result).not.toContain('{{UPGRADE_CHANNEL}}')
+    expect(result).not.toContain('{{CODEMOD_COMMAND}}')
+  })
 })
 

--- a/test/unit/nextjs-channel-detector.test.ts
+++ b/test/unit/nextjs-channel-detector.test.ts
@@ -182,7 +182,7 @@ Start
 {{/IF_BETA_CHANNEL}}End
 `
 
-      const result = processConditionalBlocks(template, true, false)
+      const result = processConditionalBlocks(template, true)
 
       expect(result).toContain('Beta content here')
       expect(result).not.toContain('{{IF_BETA_CHANNEL}}')
@@ -196,41 +196,11 @@ Start
 {{/IF_BETA_CHANNEL}}End
 `
 
-      const result = processConditionalBlocks(template, false, false)
+      const result = processConditionalBlocks(template, false)
 
       expect(result).not.toContain('Beta content here')
       expect(result).not.toContain('{{IF_BETA_CHANNEL}}')
       expect(result).not.toContain('{{/IF_BETA_CHANNEL}}')
-      expect(result).toContain('Start')
-      expect(result).toContain('End')
-    })
-
-    it('should show IF_REQUIRES_CANARY content when requiresCanary is true', () => {
-      const template = `
-Start
-{{IF_REQUIRES_CANARY}}Canary content here
-{{/IF_REQUIRES_CANARY}}End
-`
-
-      const result = processConditionalBlocks(template, false, true)
-
-      expect(result).toContain('Canary content here')
-      expect(result).not.toContain('{{IF_REQUIRES_CANARY}}')
-      expect(result).not.toContain('{{/IF_REQUIRES_CANARY}}')
-    })
-
-    it('should hide IF_REQUIRES_CANARY content when requiresCanary is false', () => {
-      const template = `
-Start
-{{IF_REQUIRES_CANARY}}Canary content here
-{{/IF_REQUIRES_CANARY}}End
-`
-
-      const result = processConditionalBlocks(template, false, false)
-
-      expect(result).not.toContain('Canary content here')
-      expect(result).not.toContain('{{IF_REQUIRES_CANARY}}')
-      expect(result).not.toContain('{{/IF_REQUIRES_CANARY}}')
       expect(result).toContain('Start')
       expect(result).toContain('End')
     })
@@ -244,30 +214,12 @@ Start
 {{/IF_BETA_CHANNEL}}End
 `
 
-      const result = processConditionalBlocks(template, true, false)
+      const result = processConditionalBlocks(template, true)
 
       expect(result).toContain('Beta 1')
       expect(result).toContain('Beta 2')
       expect(result).toContain('Middle')
       expect(result).not.toContain('{{IF_BETA_CHANNEL}}')
-    })
-
-    it('should handle both types of conditional blocks', () => {
-      const template = `
-Start
-{{IF_BETA_CHANNEL}}Beta content
-{{/IF_BETA_CHANNEL}}Middle
-{{IF_REQUIRES_CANARY}}Canary content
-{{/IF_REQUIRES_CANARY}}End
-`
-
-      const result = processConditionalBlocks(template, true, true)
-
-      expect(result).toContain('Beta content')
-      expect(result).toContain('Canary content')
-      expect(result).toContain('Middle')
-      expect(result).not.toContain('{{IF_BETA_CHANNEL}}')
-      expect(result).not.toContain('{{IF_REQUIRES_CANARY}}')
     })
 
     it('should handle multiline content within blocks', () => {
@@ -278,7 +230,7 @@ Line 2
 Line 3{{/IF_BETA_CHANNEL}}End
 `
 
-      const result = processConditionalBlocks(template, true, false)
+      const result = processConditionalBlocks(template, true)
 
       expect(result).toContain('Line 1')
       expect(result).toContain('Line 2')
@@ -289,11 +241,11 @@ Line 3{{/IF_BETA_CHANNEL}}End
     it('should handle inline conditional blocks', () => {
       const template = 'Start {{IF_BETA_CHANNEL}}[ ] Beta task{{/IF_BETA_CHANNEL}}[ ] Normal task'
 
-      const resultWithBeta = processConditionalBlocks(template, true, false)
+      const resultWithBeta = processConditionalBlocks(template, true)
       expect(resultWithBeta).toContain('[ ] Beta task')
       expect(resultWithBeta).toContain('[ ] Normal task')
 
-      const resultWithoutBeta = processConditionalBlocks(template, false, false)
+      const resultWithoutBeta = processConditionalBlocks(template, false)
       expect(resultWithoutBeta).not.toContain('[ ] Beta task')
       expect(resultWithoutBeta).toContain('[ ] Normal task')
     })
@@ -301,7 +253,7 @@ Line 3{{/IF_BETA_CHANNEL}}End
     it('should handle empty conditional blocks', () => {
       const template = 'Start {{IF_BETA_CHANNEL}}{{/IF_BETA_CHANNEL}}End'
 
-      const result = processConditionalBlocks(template, true, false)
+      const result = processConditionalBlocks(template, true)
 
       expect(result).toBe('Start End')
     })
@@ -314,7 +266,7 @@ Before
 Regular content
 `
 
-      const result = processConditionalBlocks(template, false, false)
+      const result = processConditionalBlocks(template, false)
 
       expect(result).toContain('Before')
       expect(result).toContain('After')


### PR DESCRIPTION
We have `{{ IF_BETA_CHANNEL }}` in the prompt, we now handle them by replacing it with the detected version of used nextjs

`{{ IF_REQUIRES_CANARY }}` is not needed anymore cause most of the rendering features are guard behind `cacheComponents` flag now