### PR TITLE
fix: generateImageMetadata receives already awaited params

### DIFF
--- a/src/resources/(nextjs16)/migration/nextjs-16-migration-examples.md
+++ b/src/resources/(nextjs16)/migration/nextjs-16-migration-examples.md
@@ -418,7 +418,6 @@ export default async function Image({ params, id }) {
 }
 
 export async function generateImageMetadata({ params }) {
-  const resolvedParams = await params  // params is now a Promise
   return [
     { id: 'default', size: { width: 1200, height: 630 } },
     { id: 'large', size: { width: 1800, height: 945 } }


### PR DESCRIPTION
The `generateImageMetadata` receives already awaited/resolved params