### PR TITLE
ci: add job to bump version

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,83 @@
+name: Version Bump and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - custom
+        default: 'patch'
+      custom_version:
+        description: 'Custom version (only used if version_type is "custom")'
+        required: false
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump version
+        id: version_bump
+        run: |
+          if [ "${{ inputs.version_type }}" = "custom" ]; then
+            if [ -z "${{ inputs.custom_version }}" ]; then
+              echo "Error: Custom version is required when version_type is 'custom'"
+              exit 1
+            fi
+            pnpm version ${{ inputs.custom_version }} --no-git-tag-version
+            NEW_VERSION="${{ inputs.custom_version }}"
+          else
+            pnpm version ${{ inputs.version_type }} --no-git-tag-version
+            NEW_VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "New version: ${NEW_VERSION}"
+
+      - name: Commit and push changes
+        run: |
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.version_bump.outputs.new_version }}"
+          git tag -a "v${{ steps.version_bump.outputs.new_version }}" -m "Release v${{ steps.version_bump.outputs.new_version }}"
+          git push origin ${{ github.ref_name }}
+          git push origin "v${{ steps.version_bump.outputs.new_version }}"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version_bump.outputs.new_version }}
+          release_name: Release v${{ steps.version_bump.outputs.new_version }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Add a ci job to auto bump the version, that you can trigger from github actions to upgrade the version to next patch/minor/major or custom version. Then the git push will auto trigger the release