### PR TITLE
Add troubleshooting section for common user issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,29 @@ You can also delete your local telemetry data at any time:
 rm -rf ~/.next-devtools-mcp
 ```
 
+## Troubleshooting
+
+### Module Not Found Error
+
+If you encounter an error like:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '...\next-devtools-mcp\dist\resources\(cache-components)\...'
+```
+
+**Solution:** Clear your npx cache and restart your MCP client (Cursor, Claude Code, etc.). The server will be freshly installed.
+
+### "No server info found" Error
+
+If you see `[error] No server info found`:
+
+**Solutions:**
+1. Make sure your Next.js dev server is running: `npm run dev`
+2. If using Next.js 15 or earlier, use the `upgrade_nextjs_16` tool to upgrade to Next.js 16+
+3. Verify your dev server started successfully without errors
+
+**Note:** The `nextjs_index` and `nextjs_call` tools require Next.js 16+ with a running dev server. Other tools (`nextjs_docs`, `browser_eval`, `upgrade_nextjs_16`, `enable_cache_components`) work without a running server.
+
 ## Local Development
 
 To run the MCP server locally for development:


### PR DESCRIPTION
Users on Windows have been hitting a module resolution error when npx tries to load the MCP server. The error shows up as `ERR_MODULE_NOT_FOUND` pointing to paths with parentheses like `(cache-components)` in the directory structure. This happens because npx's cache can get stale or corrupted, particularly on Windows where parentheses in paths can cause module resolution issues.

The fix is simple - clearing the npx cache resolves it - but users had no way to discover this solution on their own. They'd see the cryptic error and have to reach out for support or dig through issues.

This adds a troubleshooting section to the README documenting both this npx cache issue and the "No server info found" error (which happens when users try to use runtime diagnostic tools without a running dev server). The guidance is intentionally concise - just tells users to clear the cache without overwhelming them with platform-specific commands.

Now users can self-serve these common fixes instead of getting stuck during setup.