### PR TITLE
Fix screenshot action using wrong Playwright MCP tool name

### DIFF
--- a/src/tools/browser-eval.ts
+++ b/src/tools/browser-eval.ts
@@ -255,7 +255,7 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
         break
 
       case "screenshot":
-        toolName = "browser_screenshot"
+        toolName = "browser_take_screenshot"
         toolArgs = { fullPage: args.fullPage }
         break
 


### PR DESCRIPTION
The screenshot action in `browser_eval` was calling `browser_screenshot` but Playwright MCP renamed this tool to `browser_take_screenshot` in a recent version. This caused screenshot attempts to fail with `Tool "browser_screenshot" not found`.

The fix updates the tool name mapping in the screenshot case to use the correct `browser_take_screenshot` name that Playwright MCP expects.

Fixes https://github.com/vercel/next-devtools-mcp/issues/94

```
> take a screenshot of homepage

⏺ next-devtools - browser_eval (MCP)(action: "start")
  ⎿  {
       "success": true,
       "message": "Browser automation started (chrome, headless: true)",
     … +4 lines (ctrl+o to expand)

⏺ next-devtools - browser_eval (MCP)(action: "navigate", url: "http://localhost:3000")
  ⎿  {
       "success": true,
       "action": "navigate",
     … +18 lines (ctrl+o to expand)

⏺ next-devtools - browser_eval (MCP)(action: "screenshot", fullPage: true)
  ⎿  {
       "success": true,
       "action": "screenshot",
     … +121 lines (ctrl+o to expand)

⏺ Read(/var/folders/p3/5q9n2fpn4y16zkx41c7d3dl40000gn/T/playwright-mcp-output/1764037588
      401/page-2025-11-25T02-26-31-831Z.png)
  ⎿  Read image (5.9KB)

⏺ Screenshot taken. The homepage shows:
  - "hello world" text at the top
  - A Next.js Dev Tools button in the bottom left corner

  Screenshot saved to: /var/folders/p3/5q9n2fpn4y16zkx41c7d3dl40000gn/T/playwright-m
  cp-output/1764037588401/page-2025-11-25T02-26-31-831Z.png
```