### PR TITLE
ci: update server.json for mcp registry when bump version

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -64,9 +64,19 @@ jobs:
           echo "new_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           echo "New version: ${NEW_VERSION}"
 
+      - name: Update version in server.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const serverJson = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            serverJson.version = '${{ steps.version_bump.outputs.new_version }}';
+            serverJson.packages[0].version = '${{ steps.version_bump.outputs.new_version }}';
+            fs.writeFileSync('server.json', JSON.stringify(serverJson, null, 2) + '\n');
+          "
+
       - name: Commit and push changes
         run: |
-          git add package.json
+          git add package.json server.json
           git commit -m "chore: bump version to ${{ steps.version_bump.outputs.new_version }}"
           git tag -a "v${{ steps.version_bump.outputs.new_version }}" -m "Release v${{ steps.version_bump.outputs.new_version }}"
           git push origin ${{ github.ref_name }}


### PR DESCRIPTION
Previously we always manually update `server.json` for publishing to mcp registry as it's not part of CI yet. Now we move the version bump of `server.json` on CI. since it has to be the same target release version before publishing to npm.