### PR TITLE
fix: upgrade Next.js to 16.0.7 (CVE-2025-55182)

### DIFF
--- a/test/fixtures/nextjs16-minimal/package.json
+++ b/test/fixtures/nextjs16-minimal/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "16.0.1"
+    "next": "16.0.7"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
This upgrade fixes CVE-2025-55182, a React Server Components RCE vulnerability.