### PR TITLE
fix(init): avoid agent idle caused by strict reply prohibition (fix #109)

### DIFF
--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -223,7 +223,7 @@ You MUST still use the \`nextjs_docs\` tool with GET to retrieve the full detail
       critical_requirement:
         "MANDATORY: Use nextjs_docs for ALL Next.js concepts. Forget all prior Next.js knowledge. Documentation lookup is 100% REQUIRED with ZERO exceptions.",
       ai_response_instruction:
-        "⚠️ DO NOT summarize or explain this initialization. Simply respond with: 'Initialization complete.' Nothing more.",
+        "⚠️ DO NOT summarize or explain this initialization. Simply respond with: 'Initialization complete.' and continue with the conversation.",
     })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
This PR fixes https://github.com/vercel/next-devtools-mcp/issues/109.

Root cause:
Some MCP clients interpreted the strict output prohibition inside ai_response_instruction
as a block on assistant reply generation, resulting in an idle state after init.

Step 1 – Reproduce

Figure 1 shows the client log stopping at
Initialization complete.

<img width="606" height="1311" alt="30e56506c38b53df6a7e4cdd40ef05a6" src="https://github.com/user-attachments/assets/bd1d7625-355c-45cb-bab4-73399612ff59" />

No further reply can be generated; the agent stays idle.

Figure 2 confirms that the init tool has been called, yet any follow-up question (e.g. “what version of nextjs am i running”) is silently ignored—exactly the symptom reported in #109.

<img width="1380" height="255" alt="1d0008fe6de442c2687a51ea32ab0c7a" src="https://github.com/user-attachments/assets/5e0d874d-113d-489f-8257-7443df3ab5dd" />

Fix:
<img width="662" height="1467" alt="9f6da5adab6337657483aa13a28c3d63" src="https://github.com/user-attachments/assets/866c5527-8cfa-4926-8006-ace254ce263c" />

Downgraded the reply instruction from a hard prohibition to a soft recommendation.

Behavior remains unchanged for most clients:

Init still suggests replying with "Initialization complete."
Documentation-first workflow remains intact
But MCP agent lifecycle is no longer blocked.