### PR TITLE
Add Copilot CLI usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,36 @@ startup_timeout_ms = 20_000
 </details>
 
 <details>
+<summary>GitHub Copilot CLI</summary>
+Use the Copilot CLI to interactively add the MCP server:
+
+```bash
+/mcp add
+```
+
+Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json` and add:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "local",
+      "command": "npx",
+      "tools": [
+        "*"
+      ],
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}
+```
+
+For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+</details>
+
+<details>
 <summary>Cursor</summary>
 
 **Click the button to install:**

--- a/README.md
+++ b/README.md
@@ -98,15 +98,9 @@ Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json
 ```json
 {
   "mcpServers": {
-    "playwright": {
-      "type": "local",
+    "next-devtools": {
       "command": "npx",
-      "tools": [
-        "*"
-      ],
-      "args": [
-        "@playwright/mcp@latest"
-      ]
+      "args": ["-y", "next-devtools-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
Added instructions for using the Copilot CLI to add the MCP server.