### PR TITLE
docs: add add-mcp install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@
 - [npm](https://www.npmjs.com/) or [pnpm](https://pnpm.io/)
 
 
+### Install with add-mcp
+
+Install the MCP server for all your coding agents:
+
+```bash
+npx add-mcp next-devtools-mcp@latest
+```
+
+Add `-y` to skip the confirmation prompt and install to all detected agents already in use in the project directory.
+
+
 Add the following config to your MCP client:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npx add-mcp next-devtools-mcp@latest
 Add `-y` to skip the confirmation prompt and install to all detected agents already in use in the project directory. Add `-g` to install globally across all projects.
 
 
+### Manual installation
+
 Add the following config to your MCP client:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the MCP server for all your coding agents:
 npx add-mcp next-devtools-mcp@latest
 ```
 
-Add `-y` to skip the confirmation prompt and install to all detected agents already in use in the project directory.
+Add `-y` to skip the confirmation prompt and install to all detected agents already in use in the project directory. Add `-g` to install globally across all projects.
 
 
 Add the following config to your MCP client:


### PR DESCRIPTION
Add `add-mcp` quick install option in Getting Started

## Testing

- not run (docs change)