### PR TITLE
fix: exit server process when client disconnects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,11 @@ async function main() {
     process.exit(0)
   }
 
+  // Exit when the client disconnects (transport closes)
+  transport.onclose = () => {
+    shutdown()
+  }
+
   process.on('SIGINT', shutdown)
   process.on('SIGTERM', shutdown)
 }


### PR DESCRIPTION
## Summary

- Add `transport.onclose` handler to exit the server when the MCP client closes its stdio connection
- Prevents orphaned `next-devtools-mcp` processes from accumulating (~140-160MB each)
- `SIGINT`/`SIGTERM` handlers only fire on explicit signals, not when a client simply disconnects its stdio pipes