### PR TITLE
Close MCP transport gracefully on shutdown

### DIFF
--- a/src/_internal/browser-eval-manager.ts
+++ b/src/_internal/browser-eval-manager.ts
@@ -122,15 +122,16 @@ export async function stopBrowserEvalMCP(): Promise<void> {
 }
 
 /**
- * Cleanup on process exit
+ * Cleanup on process exit.
+ * Signal handling and process.exit() are intentionally left to src/index.ts
+ * so there is a single, ordered shutdown sequence. These listeners only close
+ * the Playwright MCP connection; they do not call process.exit() themselves.
  */
 process.on("SIGINT", async () => {
   await stopBrowserEvalMCP()
-  process.exit(0)
 })
 
 process.on("SIGTERM", async () => {
   await stopBrowserEvalMCP()
-  process.exit(0)
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,8 +176,18 @@ async function main() {
 
   log('Server started')
 
-  const shutdown = () => {
+  const shutdown = async () => {
     log('Server terminated')
+
+    // Close the MCP server transport before exiting so the host (e.g. Claude
+    // Code) receives a clean EOF on the stdio channel instead of an abrupt
+    // disconnect.  Without this the host reports "MCP server failed" even
+    // though the exit code is 0.
+    try {
+      await server.close()
+    } catch {
+      // Ignore close errors during shutdown
+    }
 
     const aggregationJSON = getSessionAggregationJSON()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,8 +303,18 @@ async function main() {
 
   log('Server started')
 
-  const shutdown = () => {
+  const shutdown = async () => {
     log('Server terminated')
+
+    // Close the MCP server transport before exiting so the host (e.g. Claude
+    // Code) receives a clean EOF on the stdio channel instead of an abrupt
+    // disconnect.  Without this the host reports "MCP server failed" even
+    // though the exit code is 0.
+    try {
+      await server.close()
+    } catch {
+      // Ignore close errors during shutdown
+    }
 
     const aggregationJSON = getSessionAggregationJSON()
 


### PR DESCRIPTION
## Problem

When the MCP host (e.g. Claude Code) sends `SIGTERM` to terminate the server on exit, users see:

> 1 MCP server failed

even though everything worked correctly and the exit code is `0`. The host interprets the abrupt stdio disconnect as a failure.

## Fix

`shutdown()` in `src/index.ts` called `process.exit(0)` without first telling the MCP `Server` to close, so the stdio transport was torn down abruptly instead of cleanly.

This makes `shutdown()` async and `await server.close()` before exiting, so the SDK can close the transport cleanly:

```diff
- const shutdown = () => {
+ const shutdown = async () => {
    log('Server terminated')
+   try {
+     await server.close()
+   } catch {
+     // Ignore close errors during shutdown
+   }
    // ... telemetry flush ...
    process.exit(0)
  }
```

> **Note:** this PR originally also removed duplicate `SIGINT`/`SIGTERM` handlers that called `process.exit(0)` from `src/_internal/browser-eval-manager.ts`. That file was removed by #145 in the meantime, so after rebasing onto `main` only the `src/index.ts` change remains.

Fixes #126, relates to #113