### PR TITLE
fix(browser_eval): align tool args with Playwright MCP 0.0.75 schema (target fields + fill_form)

### DIFF
--- a/src/tools/browser-eval.ts
+++ b/src/tools/browser-eval.ts
@@ -36,7 +36,16 @@ export const inputSchema = {
   url: z.string().optional().describe("URL to navigate to (required for 'navigate' action)"),
 
   element: z.string().optional().describe("Element to interact with (CSS selector or text)"),
-  ref: z.string().optional().describe("Reference to element from accessibility snapshot"),
+  ref: z
+    .string()
+    .optional()
+    .describe("Reference to element from accessibility snapshot (alias for 'target')"),
+  target: z
+    .string()
+    .optional()
+    .describe(
+      "Exact target element reference from the page snapshot, or a unique element selector. Preferred over 'ref'."
+    ),
   doubleClick: z
     .union([z.boolean(), z.string().transform((val) => val === "true")])
     .optional()
@@ -72,9 +81,17 @@ export const inputSchema = {
     .describe("Only return error messages from console"),
 
   startElement: z.string().optional().describe("Starting element for drag operation"),
-  startRef: z.string().optional().describe("Starting element reference"),
+  startRef: z.string().optional().describe("Starting element reference (alias for 'startTarget')"),
+  startTarget: z
+    .string()
+    .optional()
+    .describe("Exact source element reference for drag. Preferred over 'startRef'."),
   endElement: z.string().optional().describe("Ending element for drag operation"),
-  endRef: z.string().optional().describe("Ending element reference"),
+  endRef: z.string().optional().describe("Ending element reference (alias for 'endTarget')"),
+  endTarget: z
+    .string()
+    .optional()
+    .describe("Exact target element reference for drag. Preferred over 'endRef'."),
 
   files: z.array(z.string()).optional().describe("File paths to upload"),
 }
@@ -134,6 +151,7 @@ type BrowserEvalArgs = {
   url?: string
   element?: string
   ref?: string
+  target?: string
   doubleClick?: boolean | string
   button?: "left" | "right" | "middle"
   modifiers?: string[]
@@ -144,8 +162,10 @@ type BrowserEvalArgs = {
   errorsOnly?: boolean | string
   startElement?: string
   startRef?: string
+  startTarget?: string
   endElement?: string
   endRef?: string
+  endTarget?: string
   files?: string[]
 }
 
@@ -215,7 +235,7 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
         toolName = "browser_click"
         toolArgs = {
           element: args.element,
-          ref: args.ref,
+          target: args.target ?? args.ref,
           doubleClick: args.doubleClick,
           button: args.button,
           modifiers: args.modifiers,
@@ -229,7 +249,7 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
         toolName = "browser_type"
         toolArgs = {
           element: args.element,
-          ref: args.ref,
+          target: args.target ?? args.ref,
           text: args.text,
         }
         break
@@ -250,7 +270,7 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
         toolArgs = {
           function: args.script,
           element: args.element,
-          ref: args.ref,
+          target: args.target ?? args.ref,
         }
         break
 
@@ -271,9 +291,9 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
         toolName = "browser_drag"
         toolArgs = {
           startElement: args.startElement,
-          startRef: args.startRef,
+          startTarget: args.startTarget ?? args.startRef,
           endElement: args.endElement,
-          endRef: args.endRef,
+          endTarget: args.endTarget ?? args.endRef,
         }
         break
 

--- a/src/tools/browser-eval.ts
+++ b/src/tools/browser-eval.ts
@@ -61,8 +61,20 @@ export const inputSchema = {
   fields: z
     .array(
       z.object({
-        selector: z.string(),
-        value: z.string(),
+        element: z.string().optional().describe("Human-readable element description"),
+        target: z
+          .string()
+          .optional()
+          .describe(
+            "Exact target element reference from the snapshot, or a unique selector. Preferred over 'selector'."
+          ),
+        selector: z.string().optional().describe("Alias for 'target' (back-compat)"),
+        name: z.string().optional().describe("Human-readable field name"),
+        type: z
+          .enum(["textbox", "checkbox", "radio", "combobox", "slider"])
+          .optional()
+          .describe("Field type (required by Playwright MCP)"),
+        value: z.string().describe("Value to fill into the field"),
       })
     )
     .optional()
@@ -156,7 +168,14 @@ type BrowserEvalArgs = {
   button?: "left" | "right" | "middle"
   modifiers?: string[]
   text?: string
-  fields?: Array<{ selector: string; value: string }>
+  fields?: Array<{
+    element?: string
+    target?: string
+    selector?: string
+    name?: string
+    type?: "textbox" | "checkbox" | "radio" | "combobox" | "slider"
+    value: string
+  }>
   script?: string
   fullPage?: boolean | string
   errorsOnly?: boolean | string
@@ -259,7 +278,15 @@ export async function handler(args: BrowserEvalArgs): Promise<string> {
           throw new Error("Fields are required for fill_form action")
         }
         toolName = "browser_fill_form"
-        toolArgs = { fields: args.fields }
+        toolArgs = {
+          fields: args.fields.map((f) => ({
+            element: f.element,
+            target: f.target ?? f.selector,
+            name: f.name,
+            type: f.type,
+            value: f.value,
+          })),
+        }
         break
 
       case "evaluate":


### PR DESCRIPTION
## What

`@playwright/mcp@0.0.75` (current `@latest`, auto-installed by the `browser_eval` wrapper) renamed the locator field and changed the `fill_form` field shape. The wrapper forwarded the old names, so calls failed upstream with `InputValidationError`.

| action | old (sent) | new (upstream 0.0.75) |
|--------|-----------|------------------------|
| `browser_click` | `ref` | `target` |
| `browser_type` | `ref` | `target` |
| `browser_evaluate` | `ref` | `target` |
| `browser_drag` | `startRef` / `endRef` | `startTarget` / `endTarget` |
| `browser_fill_form` | `{ selector, value }` | `{ element?, target, name, type, value }` |

All names/shapes were **verified against the live `@playwright/mcp@0.0.75` server** via an MCP `tools/list` introspection (not just docs). The `fill_form` field `type` is the enum `textbox | checkbox | radio | combobox | slider`.

## How

- Forward the new upstream names for `click` / `type` / `evaluate` / `drag`.
- Rewrite the `fill_form` field schema to `{ element?, target, name, type, value }` and map it through.
- Keep `ref` / `startRef` / `endRef` and `fields[].selector` accepted as **back-compat aliases** (`target = args.target ?? args.ref`, `f.target ?? f.selector`), so existing callers don't break.

## Verification

- `pnpm typecheck` ✅  `pnpm build` ✅  `pnpm test` ✅ (38/38)
- Upstream schema confirmed live via `tools/list` against `@playwright/mcp@0.0.75`

Fixes #136