### PR TITLE
test: fix flaky Windows CI failure in nextjs-runtime-discovery teardown

### DIFF
--- a/test/unit/nextjs-runtime-discovery.test.ts
+++ b/test/unit/nextjs-runtime-discovery.test.ts
@@ -41,6 +41,9 @@ function forceKillProcessTree(proc: ChildProcess): void {
 const FIXTURE_SOURCE = join(__dirname, "../fixtures/nextjs16-minimal")
 const TEST_PORT = 3456
 const SERVER_STARTUP_TIMEOUT = 180000
+// Teardown kills the dev server and rm -rf's a temp dir containing a full
+// node_modules; on Windows CI this can exceed vitest's default 10s hookTimeout.
+const CLEANUP_TIMEOUT = 60000
 const TEST_TIMEOUT = 240000
 
 describe("nextjs-runtime-discovery", () => {
@@ -194,7 +197,7 @@ describe("nextjs-runtime-discovery", () => {
         console.error("[Test] Failed to clean up temp directory:", error)
       }
     }
-  })
+  }, CLEANUP_TIMEOUT)
 
   it(
     "should discover Next.js server on non-standard port via process discovery",


### PR DESCRIPTION
## Problem

`test/unit/nextjs-runtime-discovery.test.ts` intermittently fails on **windows-latest** CI with:

```
Error: Hook timed out in 10000ms.
 ❯ test/unit/nextjs-runtime-discovery.test.ts:156  (afterAll)
```

All **38 tests pass** — only the `afterAll` teardown trips. It kills the spawned Next.js dev server and then `rm -rf`s a temp dir containing a full `node_modules`; on Windows runners that cleanup takes ~14s, exceeding vitest's global `hookTimeout` (10000ms). ubuntu-latest is fast enough to slip under the limit, so it only flakes on Windows.

## Fix

`beforeAll` already passes `SERVER_STARTUP_TIMEOUT`; give `afterAll` an explicit `CLEANUP_TIMEOUT` (60s) so teardown isn't capped by the 10s global hook timeout. Pure test-timeout change — no product code touched.

## Verification

- `pnpm typecheck` ✅  `pnpm build` ✅  affected test ✅ locally
- Windows CI on this PR is the real proof (watching).

_Discovered while CI flaked on an unrelated PR (#141)._