### PR TITLE
feat(browser_eval): support 'chromium' browser (Linux arm64)

### DIFF
--- a/src/_internal/browser-eval-manager.ts
+++ b/src/_internal/browser-eval-manager.ts
@@ -48,7 +48,7 @@ export async function ensureBrowserEvalMCP(): Promise<void> {
  * Start playwright-mcp server and connect to it
  */
 export async function startBrowserEvalMCP(options?: {
-  browser?: "chrome" | "firefox" | "webkit" | "msedge"
+  browser?: "chrome" | "chromium" | "firefox" | "webkit" | "msedge"
   headless?: boolean
 }): Promise<MCPConnection> {
   // Ensure playwright-mcp is installed

--- a/src/tools/browser-eval.ts
+++ b/src/tools/browser-eval.ts
@@ -25,9 +25,11 @@ export const inputSchema = {
     .describe("The action to perform using browser automation"),
 
   browser: z
-    .enum(["chrome", "firefox", "webkit", "msedge"])
+    .enum(["chrome", "chromium", "firefox", "webkit", "msedge"])
     .optional()
-    .describe("Browser to use (default: chrome). Only used with 'start' action."),
+    .describe(
+      "Browser to use (default: chrome). Use 'chromium' on platforms without a Chrome build (e.g. Linux arm64). Only used with 'start' action."
+    ),
   headless: z
     .union([z.boolean(), z.string().transform((val) => val === "true")])
     .optional()
@@ -129,7 +131,7 @@ type BrowserEvalArgs = {
     | "drag"
     | "upload_file"
     | "list_tools"
-  browser?: "chrome" | "firefox" | "webkit" | "msedge"
+  browser?: "chrome" | "chromium" | "firefox" | "webkit" | "msedge"
   headless?: boolean | string
   url?: string
   element?: string


### PR DESCRIPTION
## Problem

On platforms where the only available Chrome build is **Chromium** (e.g. **Linux arm64**, per #123), `browser_eval` can't be used — the `browser` enum only accepted `chrome | firefox | webkit | msedge`.

## Fix

Add `chromium` to the `browser` enum (tool input schema + arg type) and the manager option type. It's forwarded to Playwright MCP as `--browser chromium`.

## Verification (end-to-end, not just types)

Tested against the real **`@playwright/mcp@0.0.75`** (current `@latest`) via MCP:

1. `--browser chromium` is recognized → resolves to the `chrome-for-testing` build.
2. After installing that build, started the server with `--browser chromium` and issued a `browser_navigate` call → **launched and loaded the page successfully** (`isError: undefined`).

Plus: `pnpm typecheck` ✅  `pnpm build` ✅  `pnpm test` ✅ (38/38).

Fixes #123