### PR TITLE
fix: preserve tool input types and required fields

### DIFF
--- a/.changeset/accurate-tool-input-schemas.md
+++ b/.changeset/accurate-tool-input-schemas.md
@@ -1,0 +1,5 @@
+---
+"next-devtools-mcp": patch
+---
+
+Generate MCP input schemas with the SDK converter so object arguments, required fields, and accepted port types match runtime validation.

--- a/src/_internal/tool-input-schema.ts
+++ b/src/_internal/tool-input-schema.ts
@@ -1,0 +1,7 @@
+import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js"
+import { z } from "zod"
+
+export function toolInputSchema(shape: Record<string, z.ZodTypeAny>) {
+  // Describe inputs before transforms (e.g. string OR numeric ports).
+  return toJsonSchemaCompat(z.object(shape), { pipeStrategy: "input" })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import { z } from "zod"
+import { toolInputSchema } from "./_internal/tool-input-schema.js"
 import { spawn } from "child_process"
 import { fileURLToPath } from "url"
 import { dirname, join } from "path"
@@ -31,15 +32,6 @@ const toolNameToTelemetryName: Record<string, McpToolName> = {
   nextjs_call: "mcp/nextjs_call",
 }
 
-// Type definitions
-interface JSONSchema {
-  type?: string
-  description?: string
-  properties?: Record<string, JSONSchema>
-  items?: JSONSchema
-  enum?: unknown[]
-}
-
 // Create server
 const server = new Server(
   {
@@ -59,13 +51,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: tools.map((tool) => ({
       name: tool.metadata.name,
       description: tool.metadata.description,
-      inputSchema: {
-        type: "object",
-        properties: Object.entries(tool.inputSchema).reduce((acc, [key, zodSchema]) => {
-          acc[key] = zodSchemaToJsonSchema(zodSchema)
-          return acc
-        }, {} as Record<string, JSONSchema>),
-      },
+      inputSchema: toolInputSchema(tool.inputSchema),
     })),
   }
 })
@@ -104,49 +90,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     ],
   }
 })
-
-function zodSchemaToJsonSchema(zodSchema: z.ZodTypeAny): JSONSchema {
-  const description = zodSchema._def?.description
-
-  if (zodSchema._def?.typeName === "ZodString") {
-    return { type: "string", description }
-  }
-  if (zodSchema._def?.typeName === "ZodNumber") {
-    return { type: "number", description }
-  }
-  if (zodSchema._def?.typeName === "ZodBoolean") {
-    return { type: "boolean", description }
-  }
-  if (zodSchema._def?.typeName === "ZodArray") {
-    return {
-      type: "array",
-      description,
-      items: zodSchemaToJsonSchema(zodSchema._def.type),
-    }
-  }
-  if (zodSchema._def?.typeName === "ZodObject") {
-    const shape = zodSchema._def.shape()
-    const properties: Record<string, JSONSchema> = {}
-    for (const [key, value] of Object.entries(shape)) {
-      properties[key] = zodSchemaToJsonSchema(value as z.ZodTypeAny)
-    }
-    return { type: "object", description, properties }
-  }
-  if (zodSchema._def?.typeName === "ZodEnum") {
-    return { type: "string", enum: zodSchema._def.values, description }
-  }
-  if (zodSchema._def?.typeName === "ZodOptional") {
-    return zodSchemaToJsonSchema(zodSchema._def.innerType)
-  }
-  if (zodSchema._def?.typeName === "ZodUnion") {
-    const options = zodSchema._def.options
-    if (options.length === 2) {
-      return zodSchemaToJsonSchema(options[0])
-    }
-  }
-
-  return { type: "string", description }
-}
 
 function parseToolArgs(
   schema: Record<string, z.ZodTypeAny>,

--- a/test/unit/tool-input-schema.test.ts
+++ b/test/unit/tool-input-schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv-provider.js"
+import { toolInputSchema } from "../../src/_internal/tool-input-schema.js"
+import { inputSchema as call } from "../../src/tools/nextjs_call.js"
+import { inputSchema as index } from "../../src/tools/nextjs_index.js"
+
+describe("advertised tool input schemas", () => {
+  const jsonSchema = toolInputSchema(call)
+  const validate = new AjvJsonSchemaValidator().getValidator(jsonSchema)
+
+  it.each([
+    { port: 3000, toolName: "get_errors" },
+    { port: "3000", toolName: "get_server_action_by_id", args: { actionId: "test" } },
+    { port: 3000, toolName: "example", args: { nested: { value: [null, true, 1] } } },
+  ])("accepts the same valid arguments as the tool: %j", (args) => {
+    expect(validate(args).valid).toBe(true)
+    expect(z.object(call).safeParse(args).success).toBe(true)
+  })
+
+  it.each([
+    {},
+    { port: "3000" },
+    { toolName: "get_errors" },
+    { port: "3000", toolName: "get_errors", args: "{}" },
+    { port: false, toolName: "get_errors" },
+  ])("rejects the same invalid arguments as the tool: %j", (args) => {
+    expect(validate(args).valid).toBe(false)
+    expect(z.object(call).safeParse(args).success).toBe(false)
+  })
+
+  it("preserves descriptions and keeps discovery's port optional", () => {
+    const properties = jsonSchema.properties as Record<string, { description?: string }>
+    expect(properties.args.description).toContain("MUST be an object")
+    const validateIndex = new AjvJsonSchemaValidator().getValidator(toolInputSchema(index))
+    expect(validateIndex({}).valid).toBe(true)
+    expect(validateIndex({ port: 3000 }).valid).toBe(true)
+    expect(validateIndex({ port: "3000" }).valid).toBe(true)
+  })
+})


### PR DESCRIPTION
`tools/list` currently describes `nextjs_call.args` as a string, drops numeric ports, and omits required fields. A schema-validating MCP client can reject the documented Server Action lookup before it reaches the tool.

Use the MCP SDK's existing Zod-to-JSON-Schema converter for the complete input object. This preserves records, unions, descriptions, and required fields, with input types taken before transforms. Adds a patch changeset.

Validation:
- `pnpm build`, `pnpm typecheck`, and the complete `pnpm exec vitest run`: **42 tests passed**.
- Added nine schema contract cases comparing advertised validation with the runtime Zod schema.
- Connected over stdio, captured a Server Action ID from a real Next.js 16.3.4 browser submission, validated the object arguments with AJV, and resolved the action to its source file.

Local validation used macOS arm64, Node.js 24.19.0, and pnpm 9.15.9. The uploaded GitHub-signed commit has the same Git tree as the tested checkout.
