### PR TITLE
fix: fall back when installed Next.js has no bundled docs

### DIFF
--- a/.changeset/missing-bundled-docs-fallback.md
+++ b/.changeset/missing-bundled-docs-fallback.md
@@ -1,0 +1,5 @@
+---
+"next-devtools-mcp": patch
+---
+
+Provide online documentation guidance when the installed Next.js package has no bundled docs, and distinguish this from missing dependencies.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Output: JSON with the tool's result.
 <details>
 <summary><code>nextjs_docs</code> — find version-accurate docs</summary>
 
-Does **not** fetch docs. Next.js 16+ ships its full docs (markdown, matching your installed version) at `node_modules/next/dist/docs/`. This tool returns that path and how to read it, so the agent uses version-accurate docs instead of training-data guesses. On older Next.js, it recommends `npx @next/codemod@latest upgrade latest`.
+Does **not** fetch docs. Recent Next.js releases bundle their docs (markdown, matching your installed version) at `node_modules/next/dist/docs/`. This tool checks for those files before returning reading instructions. If an installed release has no bundled docs (including early 16.x releases), it offers https://nextjs.org/docs as a fallback and asks the agent to verify APIs against the installed version. Missing dependencies receive installation guidance instead. On Next.js below 16, it recommends `npx @next/codemod@latest upgrade latest`.
 
 Input: `topic` (optional), `project_path` (optional, defaults to cwd).
 

--- a/src/tools/nextjs-docs.ts
+++ b/src/tools/nextjs-docs.ts
@@ -2,10 +2,8 @@ import { z } from "zod"
 import fs from "node:fs"
 import path from "node:path"
 
-// Next.js started bundling its full documentation inside the npm package
-// (node_modules/next/dist/docs/**/*.md) and generating an AGENTS.md that points
-// there in v16.0.0. At or above this version, agents should read those local,
-// version-accurate docs directly instead of fetching anything over MCP.
+// Older 16.x releases do not bundle docs. Check package contents before
+// directing agents to local files; the major version alone is insufficient.
 const BUNDLED_DOCS_MIN_MAJOR = 16
 
 export const inputSchema = {
@@ -30,9 +28,9 @@ export const metadata = {
   name: "nextjs_docs",
   description: `Find the version-accurate Next.js documentation for THIS project.
 
-This tool does NOT fetch documentation. Next.js 16+ ships its full docs inside the installed package at \`node_modules/next/dist/docs/\` (markdown), kept in sync with the exact version you have installed. This tool tells you where those docs are and how to read them — so you read the docs that match this project, not a generic or outdated copy.
+This tool does NOT fetch documentation. Recent Next.js releases ship their full docs inside the installed package at \`node_modules/next/dist/docs/\` (markdown), kept in sync with the exact version you have installed. This tool tells you where those docs are and how to read them — so you read the docs that match this project, not a generic or outdated copy.
 
-Call this before answering Next.js questions or writing Next.js code. Then read the relevant guide from the path it returns. If the project is on an older Next.js, it will tell you how to upgrade.`,
+Call this before answering Next.js questions or writing Next.js code. Then read the relevant guide from the path it returns. If the installed release has no bundled docs, it provides an online fallback. If dependencies are missing, it asks you to install them.`,
 }
 
 // Extract the major version from an installed version ("16.3.0-canary.49") or a
@@ -98,6 +96,25 @@ export async function handler({ topic, project_path }: NextjsDocsArgs): Promise<
   if (isModern) {
     const docsDir = path.join(projectPath, "node_modules", "next", "dist", "docs")
     const docsExist = fs.existsSync(docsDir)
+    if (!docsExist) {
+      const installed = source === "installed"
+      return JSON.stringify({
+        status: installed ? "use_online_docs" : "install_required",
+        nextVersion: version,
+        versionSource: source,
+        docsAvailable: false,
+        docsUrl: "https://nextjs.org/docs",
+        instructions: installed
+          ? [
+              `The installed Next.js ${version} package has no bundled docs directory.`,
+              "Use https://nextjs.org/docs as a fallback. Online docs may describe newer releases; verify APIs against the installed version and its release notes.",
+            ]
+          : [
+              "Install this project's dependencies with its package manager, then call nextjs_docs again to locate the installed version's docs.",
+              "Until then, refer to https://nextjs.org/docs and verify version-specific APIs.",
+            ],
+      })
+    }
     return JSON.stringify({
       status: "use_bundled_docs",
       nextVersion: version,
@@ -111,11 +128,6 @@ export async function handler({ topic, project_path }: NextjsDocsArgs): Promise<
           ? `For "${topic}", search those files, e.g.: grep -ril "${topic.replace(/"/g, "")}" node_modules/next/dist/docs`
           : "Browse the directory or grep it for the API/topic you need.",
         "Do not rely on training-data knowledge of Next.js APIs — this version may differ. Prefer the bundled docs.",
-        ...(docsExist
-          ? []
-          : [
-              "Note: the docs directory was not found. Make sure dependencies are installed (the docs ship inside the `next` package).",
-            ]),
       ],
     })
   }
@@ -127,11 +139,11 @@ export async function handler({ topic, project_path }: NextjsDocsArgs): Promise<
     versionSource: source,
     message:
       version
-        ? `This project is on Next.js ${version}. Version-accurate documentation is bundled with Next.js ${BUNDLED_DOCS_MIN_MAJOR}+ (at node_modules/next/dist/docs/) and surfaced to agents via AGENTS.md.`
-        : `No installed Next.js was detected in ${projectPath}. Next.js ${BUNDLED_DOCS_MIN_MAJOR}+ bundles version-accurate documentation at node_modules/next/dist/docs/.`,
+        ? `This project is on Next.js ${version}. Recent Next.js releases can bundle version-accurate documentation at node_modules/next/dist/docs/.`
+        : `No installed Next.js was detected in ${projectPath}. Recent Next.js releases can bundle version-accurate documentation at node_modules/next/dist/docs/.`,
     instructions: [
       `Upgrade to the latest Next.js by running: npx @next/codemod@latest upgrade latest`,
-      "After upgrading, this project will ship version-accurate docs locally and `next dev` will generate/update an AGENTS.md pointing agents to them.",
+      "After installing the upgraded version, call nextjs_docs again to check for bundled documentation.",
       "Until then, refer to https://nextjs.org/docs and avoid guessing version-specific APIs.",
     ],
   })

--- a/test/unit/nextjs-docs-gateway.test.ts
+++ b/test/unit/nextjs-docs-gateway.test.ts
@@ -86,11 +86,18 @@ describe("nextjs_docs gateway", () => {
     expect(result.nextVersion).toBeNull()
   })
 
-  it("flags missing docs dir even on a modern version", async () => {
-    tmpDir = makeProject({ installed: "16.0.0", withDocs: false })
+  it("offers a docs fallback for an installed release without bundled docs", async () => {
+    tmpDir = makeProject({ installed: "16.0.7", withDocs: false })
     const result = JSON.parse(await handler({ project_path: tmpDir }))
-    expect(result.status).toBe("use_bundled_docs")
+    expect(result.status).toBe("use_online_docs")
     expect(result.docsAvailable).toBe(false)
+    expect(result.nextVersion).toBe("16.0.7")
+    expect(result.versionSource).toBe("installed")
+    expect(result.docsUrl).toBe("https://nextjs.org/docs")
+    expect(JSON.stringify(result.instructions)).not.toContain(
+      "Make sure dependencies are installed"
+    )
+    expect(JSON.stringify(result.instructions)).toContain("16.0.7")
   })
 
   it("includes a grep hint when a topic is provided", async () => {
@@ -98,4 +105,17 @@ describe("nextjs_docs gateway", () => {
     const result = JSON.parse(await handler({ project_path: tmpDir, topic: "use cache" }))
     expect(JSON.stringify(result.instructions)).toContain("use cache")
   })
+})
+
+// Missing dependencies and old package contents require different recovery steps.
+it("asks for installation only when a modern dependency is not installed", async () => {
+  const dir = makeProject({ declared: "^16.0.0" })
+  try {
+    const result = JSON.parse(await handler({ project_path: dir }))
+    expect(result.status).toBe("install_required")
+    expect(result.docsAvailable).toBe(false)
+    expect(result.versionSource).toBe("declared")
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
An installed Next.js 16.0.7 package has no `dist/docs`, but `nextjs_docs` returns `use_bundled_docs` and suggests reinstalling dependencies. Reinstalling the same version cannot recover files that release does not ship.

Check the installed package contents before returning bundled-doc instructions. An installed release without docs receives `use_online_docs` with a version-aware fallback; a declared but missing modern dependency receives `install_required`. Update the README and add a patch changeset.

Validation:
- The regression assertions failed against the original implementation.
- `pnpm build`, `pnpm typecheck`, and the complete `pnpm exec vitest run`: **34 tests passed**.
- Real stdio MCP calls: installed Next.js **16.0.7** receives the online fallback, while **16.3.4** retains its bundled-doc response.

Local validation used macOS arm64, Node.js 24.19.0, and pnpm 9.15.9. The uploaded GitHub-signed commit has the same Git tree as the tested checkout.
