### PR TITLE
fix: preserve downstream MCP tool error status

### DIFF
--- a/.changeset/preserve-runtime-tool-errors.md
+++ b/.changeset/preserve-runtime-tool-errors.md
@@ -1,0 +1,5 @@
+---
+"next-devtools-mcp": patch
+---
+
+Preserve downstream MCP tool error status in nextjs_call responses and mark connection failures as tool errors.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
+  type CallToolResult,
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -93,7 +94,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
   const parsedArgs = parseToolArgs(tool.inputSchema, args || {})
 
-  const result = await (tool.handler as (args: Record<string, unknown>) => Promise<string>)(parsedArgs)
+  const result = await (tool.handler as (
+    args: Record<string, unknown>
+  ) => Promise<string | CallToolResult>)(parsedArgs)
+
+  if (typeof result !== "string") return result
 
   return {
     content: [

--- a/src/tools/nextjs_call.ts
+++ b/src/tools/nextjs_call.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { callNextJsTool } from "../_internal/nextjs-runtime-manager.js"
 
 export const inputSchema = {
@@ -56,10 +57,17 @@ type NextjsCallArgs = {
   args?: Record<string, unknown>
 }
 
-export async function handler(args: NextjsCallArgs): Promise<string> {
+function toolResult(payload: Record<string, unknown>): CallToolResult {
+  return {
+    ...(payload.success === false ? { isError: true } : {}),
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+  }
+}
+
+export async function handler(args: NextjsCallArgs): Promise<CallToolResult> {
   try {
     if (!args.port) {
-      return JSON.stringify({
+      return toolResult({
         success: false,
         error: "Port is required.",
         hint: "Use 'nextjs_index' first to discover available servers and their ports. If auto-discovery fails, ask the user for the port and call 'nextjs_index' with the 'port' parameter.",
@@ -67,7 +75,7 @@ export async function handler(args: NextjsCallArgs): Promise<string> {
     }
 
     if (!args.toolName) {
-      return JSON.stringify({
+      return toolResult({
         success: false,
         error: "toolName is required.",
         hint: "Use 'nextjs_index' to discover available tool names for your server.",
@@ -79,15 +87,20 @@ export async function handler(args: NextjsCallArgs): Promise<string> {
 
     const result = await callNextJsTool(portNumber, args.toolName, args.args || {})
 
-    return JSON.stringify({
-      success: true,
+    return toolResult({
+      success: !(
+        typeof result === "object" &&
+        result !== null &&
+        "isError" in result &&
+        result.isError === true
+      ),
       port: portNumber,
       toolName: args.toolName,
       result,
     })
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
-    return JSON.stringify({
+    return toolResult({
       success: false,
       error: errorMessage,
       port: args.port,

--- a/test/unit/nextjs-call-results.test.ts
+++ b/test/unit/nextjs-call-results.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { handler } from "../../src/tools/nextjs_call.js"
+import { callNextJsTool } from "../../src/_internal/nextjs-runtime-manager.js"
+
+vi.mock("../../src/_internal/nextjs-runtime-manager.js", () => ({ callNextJsTool: vi.fn() }))
+
+describe("nextjs_call result status", () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it("preserves a downstream MCP tool error and its content", async () => {
+    const downstream = { isError: true, content: [{ type: "text", text: "Missing route" }] }
+    vi.mocked(callNextJsTool).mockResolvedValue(downstream)
+    const result = await handler({ port: 3000, toolName: "compile_route" })
+    expect(result.isError).toBe(true)
+    expect(JSON.parse(result.content[0].text as string)).toEqual({
+      success: false,
+      port: 3000,
+      toolName: "compile_route",
+      result: downstream,
+    })
+  })
+
+  it("keeps successful runtime results successful", async () => {
+    const downstream = { content: [{ type: "text", text: "Healthy" }] }
+    vi.mocked(callNextJsTool).mockResolvedValue(downstream)
+    const result = await handler({ port: "3000", toolName: "get_errors" })
+    expect(result.isError).not.toBe(true)
+    expect(JSON.parse(result.content[0].text as string)).toEqual({
+      success: true,
+      port: 3000,
+      toolName: "get_errors",
+      result: downstream,
+    })
+  })
+
+  it("marks upstream request failures as tool errors", async () => {
+    vi.mocked(callNextJsTool).mockRejectedValue(new Error("Connection refused"))
+    const result = await handler({ port: 3000, toolName: "get_errors" })
+    expect(result.isError).toBe(true)
+    expect(JSON.parse(result.content[0].text as string).error).toBe("Connection refused")
+  })
+})


### PR DESCRIPTION
A downstream Next.js tool result with `isError: true` is currently wrapped in `success: true`, and the outer MCP result has no error flag. Clients can treat a failed runtime operation as successful.

Let `nextjs_call` return an MCP `CallToolResult` and preserve explicit downstream tool errors on the outer response. Request failures also set `isError`; healthy calls retain the existing JSON payload. The registration handler passes structured results through and continues wrapping string-returning tools. Adds a patch changeset.

Validation:
- Regression tests for downstream errors and request failures failed against the original implementation.
- `pnpm build`, `pnpm typecheck`, and the complete `pnpm exec vitest run`: **36 tests passed**.
- Compared a real Next.js 16.3.4 `compile_route` failure directly with the stdio proxy: both report `isError: true`, and the proxy reports `success: false`.
- Verified healthy project metadata and connection-refused responses through the same MCP interface.

This preserves explicit MCP error semantics; it does not infer failure by parsing arbitrary text content returned by downstream tools.

Local validation used macOS arm64, Node.js 24.19.0, and pnpm 9.15.9. The uploaded GitHub-signed commit has the same Git tree as the tested checkout.
