### PR TITLE
fix: exclude servers without a valid MCP tool listing

### DIFF
--- a/.changeset/validate-discovered-server-tools.md
+++ b/.changeset/validate-discovered-server-tools.md
@@ -1,0 +1,5 @@
+---
+"next-devtools-mcp": patch
+---
+
+Exclude server candidates whose MCP tool listing fails, including ordinary HTTP catch-all applications.

--- a/src/tools/nextjs_index.ts
+++ b/src/tools/nextjs_index.ts
@@ -140,22 +140,12 @@ export async function handler(args: NextjsIndexArgs = {}): Promise<string> {
     // Auto-discover all servers
     const servers = await getAllAvailableServers()
 
-    if (servers.length === 0) {
-      return JSON.stringify({
-        success: false,
-        error: "No running Next.js dev servers with MCP enabled found",
-        hint: "Make sure you're running Next.js 16+ (MCP is enabled by default). Start the dev server with 'npm run dev'. If on Next.js 15 or earlier, upgrade with 'npx @next/codemod@latest upgrade latest'.",
-        ai_instruction:
-          "IMPORTANT: Server auto-discovery may not work on all operating systems or network configurations. Please ask the user: 'What port is your Next.js dev server running on?'. Once you have the port number, call this tool again with the 'port' parameter set to the user-provided port.",
-        servers: [],
-      })
-    }
-
     // Get tools for each server
-    const serversWithTools = await Promise.all(
+    const candidatesWithTools = await Promise.all(
       servers.map(async (s) => {
         const protocol = await detectProtocol(s.port)
         const tools = await listNextJsTools(s.port)
+        if (tools.length === 0) return null
         return {
           port: s.port,
           pid: s.pid,
@@ -170,6 +160,19 @@ export async function handler(args: NextjsIndexArgs = {}): Promise<string> {
         }
       })
     )
+
+    const serversWithTools = candidatesWithTools.filter((server) => server !== null)
+
+    if (serversWithTools.length === 0) {
+      return JSON.stringify({
+        success: false,
+        error: "No running Next.js dev servers with MCP enabled found",
+        hint: "Make sure you're running Next.js 16+ (MCP is enabled by default). Start the dev server with 'npm run dev'. If on Next.js 15 or earlier, upgrade with 'npx @next/codemod@latest upgrade latest'.",
+        ai_instruction:
+          "IMPORTANT: Server auto-discovery may not work on all operating systems or network configurations. Please ask the user: 'What port is your Next.js dev server running on?'. Once you have the port number, call this tool again with the 'port' parameter set to the user-provided port.",
+        servers: [],
+      })
+    }
 
     return JSON.stringify({
       success: true,

--- a/test/unit/nextjs-index-validation.test.ts
+++ b/test/unit/nextjs-index-validation.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { handler } from "../../src/tools/nextjs_index.js"
+import {
+  getAllAvailableServers,
+  listNextJsTools,
+} from "../../src/_internal/nextjs-runtime-manager.js"
+
+vi.mock("../../src/_internal/nextjs-runtime-manager.js", () => ({
+  getAllAvailableServers: vi.fn(),
+  listNextJsTools: vi.fn(),
+  detectProtocol: vi.fn().mockResolvedValue("http"),
+  MCP_HOST: "localhost",
+}))
+
+describe("nextjs_index candidate validation", () => {
+  beforeEach(() => vi.clearAllMocks())
+  const candidates = [
+    { port: 3000, pid: 0, command: "HTTP catch-all" },
+    { port: 3001, pid: 0, command: "Next.js" },
+  ]
+  const tools = [{ name: "get_errors", inputSchema: { type: "object" } }]
+
+  it("excludes a candidate whose MCP tool listing fails", async () => {
+    vi.mocked(getAllAvailableServers).mockResolvedValue(candidates)
+    vi.mocked(listNextJsTools).mockImplementation(async (port) => (port === 3001 ? tools : []))
+    const result = JSON.parse(await handler())
+    expect(result.success).toBe(true)
+    expect(result.count).toBe(1)
+    expect(result.servers.map((server: { port: number }) => server.port)).toEqual([3001])
+    expect(result.message).toBe("Found 1 Next.js server with MCP enabled")
+  })
+
+  it("returns no-servers guidance when every candidate fails validation", async () => {
+    vi.mocked(getAllAvailableServers).mockResolvedValue(candidates)
+    vi.mocked(listNextJsTools).mockResolvedValue([])
+    const result = JSON.parse(await handler())
+    expect(result.success).toBe(false)
+    expect(result.servers).toEqual([])
+    expect(result.error).toContain("No running Next.js dev servers")
+  })
+
+  it("still rejects an invalid explicit port candidate", async () => {
+    vi.mocked(listNextJsTools).mockResolvedValue([])
+    expect(JSON.parse(await handler({ port: 3000 })).success).toBe(false)
+  })
+})


### PR DESCRIPTION
Automatic discovery currently counts an ordinary HTTP catch-all server as a Next.js MCP server, even after its tool listing fails and returns zero tools. The response can report a successful discovery consisting entirely of unusable candidates.

Filter candidates after listing their MCP tools, and compute the count and no-server guidance from the remaining servers. This matches the existing explicit-port behavior. Adds a patch changeset.

Validation:
- The mixed-candidate and all-invalid regression cases failed against the original implementation.
- `pnpm build`, `pnpm typecheck`, and the complete `pnpm exec vitest run`: **36 tests passed**.
- Started a real HTML catch-all on port 3001 alongside Next.js 16.3.4 on 3000 and 16.0.7 on 3456. Stdio discovery excluded 3001 and retained both Next.js servers; an explicit 3001 query also failed correctly.

Local validation used macOS arm64, Node.js 24.19.0, and pnpm 9.15.9. The uploaded GitHub-signed commit has the same Git tree as the tested checkout.
